### PR TITLE
deps(sdkv3): add tests for credentials refresh logic in V3 Client Builder

### DIFF
--- a/packages/core/src/shared/awsClientBuilderV3.ts
+++ b/packages/core/src/shared/awsClientBuilderV3.ts
@@ -73,7 +73,6 @@ export class DefaultAWSClientBuilderV3 implements AWSClientBuilderV3 {
         if (!opt.customUserAgent && userAgent) {
             opt.customUserAgent = [[getUserAgent({ includePlatform: true, includeClientId: true }), extensionVersion]]
         }
-        // TODO: add tests for refresh logic.
         opt.credentials = async () => {
             const creds = await shim.get()
             if (creds.expiration && creds.expiration.getTime() < Date.now()) {

--- a/packages/core/src/test/shared/defaultAwsClientBuilderV3.test.ts
+++ b/packages/core/src/test/shared/defaultAwsClientBuilderV3.test.ts
@@ -19,12 +19,59 @@ import { Client } from '@aws-sdk/smithy-client'
 import { extensionVersion } from '../../shared'
 import { assertTelemetry } from '../testUtil'
 import { telemetry } from '../../shared/telemetry'
+import { CredentialsShim } from '../../auth/deprecated/loginManager'
+import { Credentials } from '@aws-sdk/types'
+
+class MockCredentialsShim implements CredentialsShim {
+    public constructor(
+        public credentials: Credentials,
+        public readonly refreshedCredentials: Credentials
+    ) {}
+
+    public expire(): void {
+        this.credentials = {
+            ...this.credentials,
+            expiration: new Date(Date.now() - 1000 * 60 * 60 * 24),
+        }
+    }
+
+    public update(newCreds: Credentials): void {
+        this.credentials = newCreds
+    }
+
+    public async get(): Promise<Credentials> {
+        return this.credentials
+    }
+
+    public async refresh(): Promise<Credentials> {
+        return this.refreshedCredentials
+    }
+}
 
 describe('DefaultAwsClientBuilderV3', function () {
     let builder: AWSClientBuilderV3
+    let fakeContext: FakeAwsContext
+    let mockCredsShim: MockCredentialsShim
+    let oldCreds: Credentials
+    let newCreds: Credentials
 
     beforeEach(function () {
-        builder = new DefaultAWSClientBuilderV3(new FakeAwsContext())
+        fakeContext = new FakeAwsContext()
+        oldCreds = {
+            accessKeyId: 'old',
+            secretAccessKey: 'old',
+            sessionToken: 'old',
+            expiration: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        }
+        newCreds = {
+            accessKeyId: 'new',
+            secretAccessKey: 'new',
+            sessionToken: 'new',
+            expiration: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2),
+        }
+        mockCredsShim = new MockCredentialsShim(oldCreds, newCreds)
+        fakeContext.credentialsShim = mockCredsShim
+        builder = new DefaultAWSClientBuilderV3(fakeContext)
     })
 
     describe('createAndConfigureSdkClient', function () {
@@ -60,6 +107,26 @@ describe('DefaultAwsClientBuilderV3', function () {
             })
 
             assert.strictEqual(service.config.customUserAgent[0][0], 'CUSTOM USER AGENT')
+        })
+
+        it('refreshes credentials when they expire', async function () {
+            const service = await builder.createAwsService(Client as any)
+            assert.strictEqual(await service.config.credentials(), oldCreds)
+            mockCredsShim.expire()
+            assert.strictEqual(await service.config.credentials(), newCreds)
+        })
+
+        it('does not cache stale credentials', async function () {
+            const service = await builder.createAwsService(Client as any)
+            assert.strictEqual(await service.config.credentials(), oldCreds)
+            const newerCreds = {
+                accessKeyId: 'old2',
+                secretAccessKey: 'old2',
+                sessionToken: 'old2',
+                expiration: new Date(Date.now() + 1000 * 60 * 60 * 24),
+            }
+            mockCredsShim.update(newerCreds)
+            assert.strictEqual(await service.config.credentials(), newerCreds)
         })
     })
 })


### PR DESCRIPTION
## Problem
The client should not be making requests with stale credentials so we want test coverage to ensure this.

## Solution
- Create a mock credentials shim and insert it into the global context.
- The client builder will then use that shim, and we can manually expire it.
- Ensure client does not cache potentially stale credentials.

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
